### PR TITLE
Add the docker portions of pca-report-library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k @mcdonnnj
+* @ameliav @BenBreaksThings @dav3r @felddy @JCantu248 @jsf9k @king-alexander @mcdonnnj @nickviola
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   IMAGE_NAME: cisagov/pca-report-library
   PIP_CACHE_DIR: ~/.cache/pip
+  PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
+  linux/arm64,linux/ppc64le,linux/s390x"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 env:
   BUILDX_CACHE_DIR: ~/.cache/buildx
   CURL_CACHE_DIR: ~/.cache/curl
-  IMAGE_NAME: cisagov/example
+  IMAGE_NAME: cisagov/pca-report-library
   PIP_CACHE_DIR: ~/.cache/pip
   PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
   linux/arm64,linux/ppc64le,linux/s390x"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,6 @@ env:
   CURL_CACHE_DIR: ~/.cache/curl
   IMAGE_NAME: cisagov/pca-report-library
   PIP_CACHE_DIR: ~/.cache/pip
-  PLATFORMS: "linux/amd64,linux/arm/v6,linux/arm/v7,\
-  linux/arm64,linux/ppc64le,linux/s390x"
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION=unspecified
-# TODO: Update Ubuntu to Alpine with working Python package installations
+# TODO: Update python:3.9.6 image to include Alpine with working Python package installations
 # Issue: https://github.com/cisagov/pca-report-generator-docker/issues/11
 FROM python:3.9.6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,12 @@ ENV ECHO_MESSAGE="Hello World from Dockerfile"
 RUN addgroup --system --gid ${CISA_UID} cisa \
   && adduser --system --uid ${CISA_UID} --ingroup cisa cisa
 
-# RUN apk --update --no-cache add \
-# ca-certificates \
-# openssl \
-# py-pip
-
 RUN apt-get install wget
 
 RUN apt-get update && \
  apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
 
+VOLUME $CISA_HOME
 WORKDIR $PCA_REPORT_TOOLS_SRC
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
@@ -51,8 +47,3 @@ RUN ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin
 USER cisa
 WORKDIR $CISA_HOME
 CMD ["getenv"]
-
-# EXPOSE 8080/TCP
-# VOLUME ["/var/log"]
-# ENTRYPOINT ["example"]
-# CMD ["--log-level", "DEBUG"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ARG VERSION
 # Note: Additional labels are added by the build workflow.
 LABEL org.opencontainers.image.authors="mark.feldhousen@cisa.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
-LABEL version=$VERSION
 
 ARG CISA_UID=421
 ENV CISA_HOME="/home/cisa"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ ENV ECHO_MESSAGE="Hello World from Dockerfile"
 RUN addgroup --system --gid ${CISA_UID} cisa \
   && adduser --system --uid ${CISA_UID} --ingroup cisa cisa
 
-RUN apt-get install wget
-
 RUN apt-get update && \
- apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
+ apt-get install --no-install-recommends -y texlive texlive-bibtex-extra texlive-xetex wget
 
 COPY src/version.txt /src
 
@@ -29,14 +27,12 @@ WORKDIR ${PCA_REPORT_TOOLS_SRC}
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
   tar xzf sourcecode.tgz --strip-components=1 && \
+  pip install --requirement requirements.txt && \
   cp -r src/pca_report_library/assets/fonts /usr/share/fonts/truetype/ncats && \
+  fc-cache -fsv && \
+  chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv && \
+  ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin && \
   rm sourcecode.tgz
-
-RUN fc-cache -fsv
-
-RUN pip install --no-cache-dir .
-RUN chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv
-RUN ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin
 
 USER cisa
 WORKDIR ${CISA_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN apt-get install wget
 RUN apt-get update && \
  apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
 
-VOLUME $CISA_HOME
-
 COPY src/version.txt /src
 
 WORKDIR ${PCA_REPORT_TOOLS_SRC}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG VERSION=unspecified
-
+# TODO: Update Ubuntu to Alpine with working Python package installations
+# Issue: https://github.com/cisagov/pca-report-generator-docker/issues/11
 FROM python:3.9.6
 
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive
 
 USER cisa
 WORKDIR ${CISA_HOME}
-CMD ["getenv"]
+ENTRYPOINT ["pca-report-generator"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG VERSION=0.0.1
 
 FROM python:3.9.6
 
-ARG GIT_COMMIT
-ARG GIT_REMOTE
 ARG VERSION
 
 # For a list of pre-defined annotation keys and value types see:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,7 @@ RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive
 
 USER cisa
 WORKDIR ${CISA_HOME}
+# TODO: Create a shell script to improve the Docker entrypoint
+# Issue: https://github.com/cisagov/pca-report-generator-docker/issues/12
 ENTRYPOINT ["pca-report-generator"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security
 
 ARG CISA_UID=421
 ENV CISA_HOME="/home/cisa"
-ENV PCA_REPORT_TOOLS_SRC="/usr/src/pca-report-tools"
+ENV PCA_REPORT_LIBRARY_SRC="/usr/src/pca-report-tools"
 ENV ECHO_MESSAGE="Hello World from Dockerfile"
 
 RUN addgroup --system --gid ${CISA_UID} cisa \
@@ -23,15 +23,15 @@ RUN apt-get update && \
 
 COPY src/version.txt /src
 
-WORKDIR ${PCA_REPORT_TOOLS_SRC}
+WORKDIR ${PCA_REPORT_LIBRARY_SRC}
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
   tar xzf sourcecode.tgz --strip-components=1 && \
   pip install --requirement requirements.txt && \
   cp -r src/pca_report_library/assets/fonts /usr/share/fonts/truetype/ncats && \
   fc-cache -fsv && \
-  chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv && \
-  ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin && \
+  chmod +x ${PCA_REPORT_LIBRARY_SRC}/var/getenv && \
+  ln -snf ${PCA_REPORT_LIBRARY_SRC}/var/getenv /usr/local/bin && \
   rm sourcecode.tgz
 
 USER cisa

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG GIT_COMMIT=unspecified
-ARG GIT_REMOTE=unspecified
 ARG VERSION=0.0.1
 
 FROM python:3.9.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update && \
  apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
 
 VOLUME $CISA_HOME
+
+COPY src/version.txt /src
+
 WORKDIR $PCA_REPORT_TOOLS_SRC
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ VOLUME $CISA_HOME
 
 COPY src/version.txt /src
 
-WORKDIR $PCA_REPORT_TOOLS_SRC
+WORKDIR ${PCA_REPORT_TOOLS_SRC}
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
   tar xzf sourcecode.tgz --strip-components=1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,12 @@ RUN addgroup --system --gid ${CISA_UID} cisa \
 # openssl \
 # py-pip
 
-WORKDIR ${CISA_HOME}
-
 RUN apt-get install wget
 
 RUN apt-get update && \
  apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
+
+WORKDIR $PCA_REPORT_TOOLS_SRC
 
 RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
   tar xzf sourcecode.tgz --strip-components=1 && \
@@ -44,17 +44,9 @@ RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive
 
 RUN fc-cache -fsv
 
-WORKDIR $PCA_REPORT_TOOLS_SRC
-COPY . $PCA_REPORT_TOOLS_SRC
-
-RUN pip install --no-cache-dir /home/cisa/
-RUN mkdir ${PCA_REPORT_TOOLS_SRC}/var
-RUN mkdir ${PCA_REPORT_TOOLS_SRC}/var/getenv
+RUN pip install --no-cache-dir .
 RUN chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv
 RUN ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin
-
-USER root
-RUN chmod +x /home/cisa/var/getenv
 
 USER cisa
 WORKDIR $CISA_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ ARG VERSION
 # For a list of pre-defined annotation keys and value types see:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 # Note: Additional labels are added by the build workflow.
-LABEL git_commit=$GIT_COMMIT
-LABEL git_remote=$GIT_REMOTE
 LABEL org.opencontainers.image.authors="mark.feldhousen@cisa.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 LABEL version=$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,66 @@
-ARG VERSION=unspecified
+ARG GIT_COMMIT=unspecified
+ARG GIT_REMOTE=unspecified
+ARG VERSION=0.0.1
 
-FROM python:3.9.6-alpine
+FROM python:3.9.6
 
+ARG GIT_COMMIT
+ARG GIT_REMOTE
 ARG VERSION
 
 # For a list of pre-defined annotation keys and value types see:
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 # Note: Additional labels are added by the build workflow.
+LABEL git_commit=$GIT_COMMIT
+LABEL git_remote=$GIT_REMOTE
 LABEL org.opencontainers.image.authors="mark.feldhousen@cisa.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
+LABEL version=$VERSION
 
 ARG CISA_UID=421
 ENV CISA_HOME="/home/cisa"
+ENV PCA_REPORT_TOOLS_SRC="/usr/src/pca-report-tools"
 ENV ECHO_MESSAGE="Hello World from Dockerfile"
 
 RUN addgroup --system --gid ${CISA_UID} cisa \
   && adduser --system --uid ${CISA_UID} --ingroup cisa cisa
 
-RUN apk --update --no-cache add \
-ca-certificates \
-openssl \
-py-pip
+# RUN apk --update --no-cache add \
+# ca-certificates \
+# openssl \
+# py-pip
 
 WORKDIR ${CISA_HOME}
 
-RUN wget -O sourcecode.tgz https://github.com/cisagov/skeleton-python-library/archive/v${VERSION}.tar.gz && \
+RUN apt-get install wget
+
+RUN apt-get update && \
+ apt-get install --no-install-recommends -y texlive texlive-xetex texlive-bibtex-extra
+
+RUN wget -O sourcecode.tgz https://github.com/cisagov/pca-report-library/archive/v${VERSION}.tar.gz && \
   tar xzf sourcecode.tgz --strip-components=1 && \
-  pip install --requirement requirements.txt && \
-  ln -snf /run/secrets/quote.txt src/example/data/secret.txt && \
+  cp -r src/pca_report_library/assets/fonts /usr/share/fonts/truetype/ncats && \
   rm sourcecode.tgz
 
-USER cisa
+RUN fc-cache -fsv
 
-EXPOSE 8080/TCP
-VOLUME ["/var/log"]
-ENTRYPOINT ["example"]
-CMD ["--log-level", "DEBUG"]
+WORKDIR $PCA_REPORT_TOOLS_SRC
+COPY . $PCA_REPORT_TOOLS_SRC
+
+RUN pip install --no-cache-dir /home/cisa/
+RUN mkdir ${PCA_REPORT_TOOLS_SRC}/var
+RUN mkdir ${PCA_REPORT_TOOLS_SRC}/var/getenv
+RUN chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv
+RUN ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin
+
+USER root
+RUN chmod +x /home/cisa/var/getenv
+
+USER cisa
+WORKDIR $CISA_HOME
+CMD ["getenv"]
+
+# EXPOSE 8080/TCP
+# VOLUME ["/var/log"]
+# ENTRYPOINT ["example"]
+# CMD ["--log-level", "DEBUG"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,5 @@ RUN chmod +x ${PCA_REPORT_TOOLS_SRC}/var/getenv
 RUN ln -snf ${PCA_REPORT_TOOLS_SRC}/var/getenv /usr/local/bin
 
 USER cisa
-WORKDIR $CISA_HOME
+WORKDIR ${CISA_HOME}
 CMD ["getenv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG VERSION=unspecified
-# TODO: Update python:3.9.6 image to include Alpine with working Python package installations
+# TODO: Switch base Docker image from python:3.9.6 to a current
+# alpine image (e.g. python:3.10.0-alpine)
 # Issue: https://github.com/cisagov/pca-report-generator-docker/issues/11
 FROM python:3.9.6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=0.0.1
+ARG VERSION=unspecified
 
 FROM python:3.9.6
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ environment variables.  See the
 
 1. Recreate and run the container by following the [previous instructions](#running-with-docker).
 
+<!-- Not yet pushed to Docker Hub. No Image tags.
 ## Image tags ##
 
 The images of this container are tagged with [semantic
@@ -171,13 +172,13 @@ containerize.  It is recommended that most users use a version tag (e.g.
 |`cisagov/example:latest`| The most recent release image pushed to a container registry.  Pulling an image using the `:latest` tag [should be avoided.](https://vsupalov.com/docker-latest-tag/) |
 
 See the [tags tab](https://hub.docker.com/r/cisagov/example/tags) on Docker
-Hub for a list of all the supported tags.
+Hub for a list of all the supported tags. -->
 
 ## Volumes ##
 
 | Mount point | Purpose        |
 |-------------|----------------|
-| `/var/log`  |  Log storage   |
+| `/home/cisa`  |  Log storage   |
 
 ## Environment variables ##
 
@@ -199,18 +200,7 @@ Hub for a list of all the supported tags.
 |--------------|---------|
 | `quote.txt` | Replaces the secret stored in the example library's package data. |
 
-## Building from source ##
-
-Build the image locally using this git repository as the [build context](https://docs.docker.com/engine/reference/commandline/build/#git-repositories):
-
-```console
-docker build \
-  --build-arg VERSION=0.0.1 \
-  --tag cisagov/example:0.0.1 \
-  https://github.com/cisagov/example.git#develop
-```
-
-## Cross-platform builds ##
+<!-- ## Cross-platform builds ##
 
 To create images that are compatible with other platforms, you can use the
 [`buildx`](https://docs.docker.com/buildx/working-with-buildx/) feature of
@@ -224,13 +214,13 @@ Docker:
     cd example
     ```
 
-1. Create the `Dockerfile-x` file with `buildx` platform support:
+2. Create the `Dockerfile-x` file with `buildx` platform support:
 
     ```console
     ./buildx-dockerfile.sh
     ```
 
-1. Build the image using `buildx`:
+3. Build the image using `buildx`:
 
     ```console
     docker buildx build \
@@ -239,14 +229,7 @@ Docker:
       --build-arg VERSION=0.0.1 \
       --output type=docker \
       --tag cisagov/example:0.0.1 .
-    ```
-
-## New repositories from a skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
+    ``` -->
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/
 docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library:0.0.1 --LaTeX
 ```
 
-`pca-report-compiler` -  Compiles a PCA LaTeX report file,  still in development.
+`pca-report-compiler` -  Compile a PCA LaTeX report file (still in
+development):
 
 ```console
 docker run -v $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library-docker:0.0.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/
 development):
 
 ```console
-docker run -v $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library-docker:0.0.1
+docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library:0.0.1 MY_REPORT.tex
 ```
 
 `pca-report-generator-bash` - Starts up a `bash` shell in the container

--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ Hub for a list of all the supported tags. -->
 |-------------|----------------|
 | `/home/cisa`  |  Log storage   |
 
+## Ports ##
+
+There are no ports exposed by this container.
+
+<!--
+The following ports are exposed by this container:
+
+| Port | Purpose        |
+|------|----------------|
+| 8080 | Example only; nothing is actually listening on the port |
+
+The sample [Docker composition](docker-compose.yml) publishes the
+exposed port at 8080.
+-->
+
 ## Environment variables ##
 
 <!-- ### Required ###

--- a/README.md
+++ b/README.md
@@ -179,17 +179,6 @@ Hub for a list of all the supported tags.
 |-------------|----------------|
 | `/var/log`  |  Log storage   |
 
-## Ports ##
-
-The following ports are exposed by this container:
-
-| Port | Purpose        |
-|------|----------------|
-| 8080 | Example only; nothing is actually listening on the port |
-
-The sample [Docker composition](docker-compose.yml) publishes the
-exposed port at 8080.
-
 ## Environment variables ##
 
 ### Required ###

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ environment variables.  See the
 
 1. Recreate and run the container by following the [previous instructions](#running-with-docker).
 
-<!-- Not yet pushed to Docker Hub. No Image tags.
 ## Image tags ##
 
 The images of this container are tagged with [semantic

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ exposed port at 8080.
 
 | Name  | Purpose | Default |
 |-------|---------|---------|
+| `CISA_HOME` | Sets up as the working directory.  | `/home/cisa` |
 | `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` |
 | `PCA_REPORT_TOOLS_SRC` | Set as the directory for the pca-report-library codebase.  | `/usr/src/pca-report-tools` |
-| `CISA_HOME` | Sets up as the working directory.  | `/home/cisa` |
 
 ## Secrets ##
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pca-report-generator-docker 💀🐳 #
+# pca-report-generator-docker #
 
 [![GitHub Build Status](https://github.com/cisagov/pca-report-generator-docker/workflows/build/badge.svg)](https://github.com/cisagov/pca-report-generator-docker/actions/workflows/build.yml)
 [![CodeQL](https://github.com/cisagov/pca-report-generator-docker/workflows/CodeQL/badge.svg)](https://github.com/cisagov/pca-report-generator-docker/actions/workflows/codeql-analysis.yml)
@@ -10,21 +10,45 @@
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/cisagov/example)](https://hub.docker.com/r/cisagov/example)
 [![Platforms](https://img.shields.io/badge/platforms-amd64%20%7C%20arm%2Fv6%20%7C%20arm%2Fv7%20%7C%20arm64%20%7C%20ppc64le%20%7C%20s390x-blue)](https://hub.docker.com/r/cisagov/pca-report-generator-docker/tags)
 
-This is a Docker skeleton project that can be used to quickly get a
-new [cisagov](https://github.com/cisagov) GitHub Docker project
-started.  This skeleton project contains [licensing
-information](LICENSE), as well as [pre-commit hooks](https://pre-commit.com)
-and [GitHub Actions](https://github.com/features/actions) configurations
-appropriate for Docker containers and the major languages that we use.
+This is a Docker project that uses the pca-report-library package.
+
+The package is used for generating PCA reports with LaTeX and supporting scripts.
 
 ## Running ##
 
-### Running with Docker ###
+The following docker commands are available.
 
-To run the `cisagov/example` image via Docker:
+An alias can also be set beforehand to remove redundancy.
+
+`pca-report-generator` - Builds PCA LaTeX report and complies the PDF
 
 ```console
-docker run cisagov/example:0.0.1
+docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator
+```
+
+`pca-report-templates` - Exports the Report Mustache template and Manual data
+file template
+
+```console
+docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-templates
+```
+
+`pca-report-compiler` -  Compiles a PCA LaTeX report file,  still in development.
+
+```console
+docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-compiler
+```
+
+`pca-report-generator-bash` - Will SSH into the container
+
+```console
+docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator-bash
+```
+
+For debuging purposes - Will SSH into the container without an extra command
+
+```console
+docker run --rm -it --entrypoint bash cisagov/pca-report-generator
 ```
 
 ### Running with Docker Compose ###

--- a/README.md
+++ b/README.md
@@ -69,45 +69,6 @@ docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generato
     docker-compose up --detach
     ```
 
-## Using secrets with your container ##
-
-There are no secrets for this container.
-<!-- This container also supports passing sensitive values via [Docker
-secrets](https://docs.docker.com/engine/swarm/secrets/).  Passing sensitive
-values like your credentials can be more secure using secrets than using
-environment variables.  See the
-[secrets](#secrets) section below for a table of all supported secret files.
-
-1. To use secrets, create a `quote.txt` file containing the values you want set:
-
-    ```text
-    Better lock it in your pocket.
-    ```
-
-1. Then add the secret to your `docker-compose.yml` file:
-
-    ```yaml
-    ---
-    version: "3.7"
-
-    secrets:
-      quote_txt:
-        file: quote.txt
-
-    services:
-      pca-report-library:
-        image: cisagov/pca-report-library
-        volumes:
-          - type: bind
-            source: <your_log_dir>
-            target: /home/cisa
-        environment:
-          - ECHO_MESSAGE="Hello from docker-compose"
-        secrets:
-          - source: quote_txt
-            target: quote.txt
-    ``` -->
-
 ## Updating your container ##
 
 ### Docker Compose ###

--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-compiler
 docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator-bash
 ```
 
-For debuging purposes - Will SSH into the container without an extra command
-
-```console
-docker run --rm -it --entrypoint bash cisagov/pca-report-generator
-```
-
 ### Running with Docker Compose ###
 
 1. Create a `docker-compose.yml` file similar to the one below to use [Docker Compose](https://docs.docker.com/compose/).

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ Docker:
    or the command line:
 
     ```console
-    git clone https://github.com/cisagov/pca-report-library.git
-    cd example
+    git clone https://github.com/cisagov/pca-report-generator-docker.git
+    cd pca-report-generator-docker
     ```
 
 1. Create the `Dockerfile-x` file with `buildx` platform support:

--- a/README.md
+++ b/README.md
@@ -192,7 +192,18 @@ Hub for a list of all the supported tags. -->
 |--------------|---------|
 | `quote.txt` | Replaces the secret stored in the example library's package data. |
 
-<!-- ## Cross-platform builds ##
+## Building from source ##
+
+Build the image locally using this git repository as the [build context](https://docs.docker.com/engine/reference/commandline/build/#git-repositories):
+
+```console
+docker build \
+  --build-arg VERSION=0.0.1 \
+  --tag cisagov/pca-report-library:0.0.1 \
+  https://github.com/cisagov/pca-report-library.git#develop
+```
+
+## Cross-platform builds ##
 
 To create images that are compatible with other platforms, you can use the
 [`buildx`](https://docs.docker.com/buildx/working-with-buildx/) feature of
@@ -202,7 +213,7 @@ Docker:
    or the command line:
 
     ```console
-    git clone https://github.com/cisagov/example.git
+    git clone https://github.com/cisagov/pca-report-library.git
     cd example
     ```
 
@@ -220,8 +231,8 @@ Docker:
       --platform linux/amd64 \
       --build-arg VERSION=0.0.1 \
       --output type=docker \
-      --tag cisagov/example:0.0.1 .
-    ``` -->
+      --tag cisagov/pca-report-library:0.0.1 .
+    ```
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ containerize.  It is recommended that most users use a version tag (e.g.
 
 | Image:tag | Description |
 |-----------|-------------|
-|`cisagov/example:1.2.3`| An exact release version. |
-|`cisagov/example:1.2`| The most recent release matching the major and minor version numbers. |
-|`cisagov/example:1`| The most recent release matching the major version number. |
-|`cisagov/example:edge` | The most recent image built from a merge into the `develop` branch of this repository. |
-|`cisagov/example:nightly` | A nightly build of the `develop` branch of this repository. |
-|`cisagov/example:latest`| The most recent release image pushed to a container registry.  Pulling an image using the `:latest` tag [should be avoided.](https://vsupalov.com/docker-latest-tag/) |
+|`cisagov/pca-report-library:0.0.1`| An exact release version. |
+|`cisagov/pca-report-library:0.0`| The most recent release matching the major and minor version numbers. |
+|`cisagov/pca-report-library:0`| The most recent release matching the major version number. |
+|`cisagov/pca-report-library:edge` | The most recent image built from a merge into the `develop` branch of this repository. |
+|`cisagov/pca-report-library:nightly` | A nightly build of the `develop` branch of this repository. |
+|`cisagov/pca-report-library:latest`| The most recent release image pushed to a container registry.  Pulling an image using the `:latest` tag [should be avoided.](https://vsupalov.com/docker-latest-tag/) |
 
 See the [tags tab](https://hub.docker.com/r/cisagov/example/tags) on Docker
 Hub for a list of all the supported tags.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ containerize.  It is recommended that most users use a version tag (e.g.
 |`cisagov/example:latest`| The most recent release image pushed to a container registry.  Pulling an image using the `:latest` tag [should be avoided.](https://vsupalov.com/docker-latest-tag/) |
 
 See the [tags tab](https://hub.docker.com/r/cisagov/example/tags) on Docker
-Hub for a list of all the supported tags. -->
+Hub for a list of all the supported tags.
 
 ## Volumes ##
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ package, which can be used to generate Phishing Campaign Assessment (PCA) report
 
 The following Docker commands are available.
 
-An alias can also be set beforehand to remove redundancy.
+Use `--entrypoint` to select which command within `pca-report-library` to
+execute:
 
-Parameters can be added at the end. Each defaulting command prints out a help message.
+- `pca-report-generator` (this is the default entrypoint)
+- `pca-report-templates`
+- `pca-report-compiler`
+
+If no additional parameters are supplied, help text will be output.
+See below for examples:
 
 `pca-report-generator` - Creates a PCA report as a PDF
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ Hub for a list of all the supported tags.
 
 ## Volumes ##
 
-| Mount point | Purpose        |
+There are no volumes for this container.
+<!-- | Mount point | Purpose        |
 |-------------|----------------|
-| `/home/cisa`  |  Log storage   |
+| `/home/cisa`  |  Log storage   | -->
 
 ## Ports ##
 

--- a/README.md
+++ b/README.md
@@ -183,19 +183,15 @@ Hub for a list of all the supported tags.
 
 ### Required ###
 
-There are no required environment variables.
-
-<!--
 | Name  | Purpose | Default |
 |-------|---------|---------|
-| `REQUIRED_VARIABLE` | Describe its purpose. | `null` |
--->
+| `PCA_GENERATOR_IMAGE` | Docker image name. | `cisagov/pca-report-generator` |
 
-### Optional ###
+<!-- ### Optional ### -->
 
-| Name  | Purpose | Default |
+<!-- | Name  | Purpose | Default |
 |-------|---------|---------|
-| `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` |
+| `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` | -->
 
 ## Secrets ##
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following Docker commands are available.
 
 An alias can also be set beforehand to remove redundancy.
 
-`pca-report-generator` - Builds PCA LaTeX report and complies the PDF
+`pca-report-generator` - Creates a PCA report as a PDF
 
 ```console
 docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator

--- a/README.md
+++ b/README.md
@@ -174,17 +174,19 @@ Hub for a list of all the supported tags. -->
 
 ## Environment variables ##
 
-### Required ###
+<!-- ### Required ###
 
 | Name  | Purpose | Default |
 |-------|---------|---------|
-| `PCA_GENERATOR_IMAGE` | Docker image name. | `cisagov/pca-report-generator` |
+| `` |  |  | -->
 
 ### Optional ###
 
 | Name  | Purpose | Default |
 |-------|---------|---------|
 | `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` |
+| `PCA_REPORT_TOOLS_SRC` | Set as the directory for the pca-report-library codebase.  | `/usr/src/pca-report-tools` |
+| `CISA_HOME` | Sets up as the working directory.  | `/home/cisa` |
 
 ## Secrets ##
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-template
 docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-compiler
 ```
 
-`pca-report-generator-bash` - Will SSH into the container
+`pca-report-generator-bash` - Starts up a `bash` shell in the container
 
 ```console
 docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator-bash

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Docker:
     cd example
     ```
 
-2. Create the `Dockerfile-x` file with `buildx` platform support:
+1. Create the `Dockerfile-x` file with `buildx` platform support:
 
     ```console
     ./buildx-dockerfile.sh

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ development):
 docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library:0.0.1 MY_REPORT.tex
 ```
 
-`pca-report-generator-bash` - Starts up a `bash` shell in the container
+Start up a `bash` shell in a `pca-report-library` container:
 
 ```console
-docker run -v $(pwd):/home/cisa --entrypoint pca-report-generator-bash cisagov/pca-report-generator
+docker run -v $(pwd):/home/cisa --entrypoint /bin/bash --interactive --tty cisagov/pca-report-library:0.0.1
 ```
 
 ### Running with Docker Compose ###

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ environment variables.  See the
 1. Pull the new image:
 
     ```console
-    docker pull cisagov/pca-report-library
+    docker pull cisagov/pca-report-library:0.0.1
     ```
 
 1. Recreate and run the container by following the [previous instructions](#running-with-docker).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker run --rm -it --entrypoint bash cisagov/pca-report-generator
 
     services:
       pca-report-library:
-        image: cisagov/pca-report-library
+        image: cisagov/pca-report-library:0.0.1
         volumes:
           - type: bind
             source: <your_log_dir>

--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ exposed port at 8080.
 
 ## Secrets ##
 
-| Filename     | Purpose |
+There are no secrets for this container.
+<!-- | Filename     | Purpose |
 |--------------|---------|
-| `quote.txt` | Replaces the secret stored in the example library's package data. |
+| `quote.txt` | Replaces the secret stored in the example library's package data. | -->
 
 ## Building from source ##
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Build the image locally using this git repository as the [build context](https:/
 docker build \
   --build-arg VERSION=0.0.1 \
   --tag cisagov/pca-report-library:0.0.1 \
-  https://github.com/cisagov/pca-report-library.git#develop
+  https://github.com/cisagov/pca-report-generator-docker.git#develop
 ```
 
 ## Cross-platform builds ##

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generato
           - type: bind
             source: <your_log_dir>
             target: /home/cisa
-        environment:
-          - ECHO_MESSAGE="Hello from docker-compose"
     ```
 
 1. Start the container and detach:
@@ -155,7 +153,6 @@ exposed port at 8080.
 | Name  | Purpose | Default |
 |-------|---------|---------|
 | `CISA_HOME` | Sets up as the working directory.  | `/home/cisa` |
-| `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` |
 | `PCA_REPORT_TOOLS_SRC` | Set as the directory for the pca-report-library codebase.  | `/usr/src/pca-report-tools` |
 
 ## Secrets ##

--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ execute:
 If no additional parameters are supplied, help text will be output.
 See below for examples:
 
-`pca-report-generator` - Creates a PCA report as a PDF
+`pca-report-generator` - Create a PCA report as a PDF:
 
 ```console
-docker run -v $(pwd):/home/cisa cisagov/pca-report-generator:0.0.1
+docker run --volume $(pwd):/home/cisa cisagov/pca-report-library:0.0.1 MY_ASSESSMENT_ID
 ```
 
-`pca-report-templates` - Exports the Report Mustache template and Manual data
-file template
+`pca-report-templates` - Export the PCA manual data file template or Mustache
+template:
 
 ```console
-docker run -v $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library-docker:0.0.1
+docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library:0.0.1 --manualData
+
+docker run --volume $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library:0.0.1 --LaTeX
 ```
 
 `pca-report-compiler` -  Compiles a PCA LaTeX report file,  still in development.

--- a/README.md
+++ b/README.md
@@ -19,29 +19,31 @@ The following Docker commands are available.
 
 An alias can also be set beforehand to remove redundancy.
 
+Parameters can be added at the end. Each defaulting command prints out a help message.
+
 `pca-report-generator` - Creates a PCA report as a PDF
 
 ```console
-docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator
+docker run -v $(pwd):/home/cisa cisagov/pca-report-generator:0.0.1
 ```
 
 `pca-report-templates` - Exports the Report Mustache template and Manual data
 file template
 
 ```console
-docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-templates
+docker run -v $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library-docker:0.0.1
 ```
 
 `pca-report-compiler` -  Compiles a PCA LaTeX report file,  still in development.
 
 ```console
-docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-compiler
+docker run -v $(pwd):/home/cisa --entrypoint pca-report-templates cisagov/pca-report-library-docker:0.0.1
 ```
 
 `pca-report-generator-bash` - Starts up a `bash` shell in the container
 
 ```console
-docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generator-bash
+docker run -v $(pwd):/home/cisa --entrypoint pca-report-generator-bash cisagov/pca-report-generator
 ```
 
 ### Running with Docker Compose ###

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ docker run -v $(pwd):/home/cisa cisagov/pca-report-generator pca-report-generato
 
 ## Using secrets with your container ##
 
-This container also supports passing sensitive values via [Docker
+There are no secrets for this container.
+<!-- This container also supports passing sensitive values via [Docker
 secrets](https://docs.docker.com/engine/swarm/secrets/).  Passing sensitive
 values like your credentials can be more secure using secrets than using
 environment variables.  See the
@@ -105,7 +106,7 @@ environment variables.  See the
         secrets:
           - source: quote_txt
             target: quote.txt
-    ```
+    ``` -->
 
 ## Updating your container ##
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Docker:
     ./buildx-dockerfile.sh
     ```
 
-3. Build the image using `buildx`:
+1. Build the image using `buildx`:
 
     ```console
     docker buildx build \

--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ Hub for a list of all the supported tags. -->
 |-------|---------|---------|
 | `PCA_GENERATOR_IMAGE` | Docker image name. | `cisagov/pca-report-generator` |
 
-<!-- ### Optional ### -->
+### Optional ###
 
-<!-- | Name  | Purpose | Default |
+| Name  | Purpose | Default |
 |-------|---------|---------|
-| `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` | -->
+| `ECHO_MESSAGE` | Sets the message echoed by this container.  | `Hello World from Dockerfile` |
 
 ## Secrets ##
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The package is used for generating PCA reports with LaTeX and supporting scripts
 
 ## Running ##
 
-The following docker commands are available.
+The following Docker commands are available.
 
 An alias can also be set beforehand to remove redundancy.
 

--- a/README.md
+++ b/README.md
@@ -60,18 +60,14 @@ docker run --rm -it --entrypoint bash cisagov/pca-report-generator
     version: "3.7"
 
     services:
-      example:
-        image: cisagov/example:0.0.1
+      pca-report-library:
+        image: cisagov/pca-report-library
         volumes:
           - type: bind
             source: <your_log_dir>
-            target: /var/log
+            target: /home/cisa
         environment:
           - ECHO_MESSAGE="Hello from docker-compose"
-        ports:
-          - target: 8080
-            published: 8080
-            protocol: tcp
     ```
 
 1. Start the container and detach:
@@ -105,18 +101,14 @@ environment variables.  See the
         file: quote.txt
 
     services:
-      example:
-        image: cisagov/example:0.0.1
+      pca-report-library:
+        image: cisagov/pca-report-library
         volumes:
           - type: bind
             source: <your_log_dir>
-            target: /var/log
+            target: /home/cisa
         environment:
           - ECHO_MESSAGE="Hello from docker-compose"
-        ports:
-          - target: 8080
-            published: 8080
-            protocol: tcp
         secrets:
           - source: quote_txt
             target: quote.txt
@@ -149,7 +141,7 @@ environment variables.  See the
 1. Pull the new image:
 
     ```console
-    docker pull cisagov/example:0.0.1
+    docker pull cisagov/pca-report-library
     ```
 
 1. Recreate and run the container by following the [previous instructions](#running-with-docker).

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/cisagov/example)](https://hub.docker.com/r/cisagov/example)
 [![Platforms](https://img.shields.io/badge/platforms-amd64%20%7C%20arm%2Fv6%20%7C%20arm%2Fv7%20%7C%20arm64%20%7C%20ppc64le%20%7C%20s390x-blue)](https://hub.docker.com/r/cisagov/pca-report-generator-docker/tags)
 
-This is a Docker project that uses the pca-report-library package.
-
-The package is used for generating PCA reports with LaTeX and supporting scripts.
+This is a Docker project that containerizes the [pca-report-library](https://github.com/cisagov/pca-report-library)
+package, which can be used to generate Phishing Campaign Assessment (PCA) reports.
 
 ## Running ##
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,4 @@ services:
     image: cisagov/pca-report-library
     init: true
     restart: "no"
-    command: --version
+    command: pca-report-generator --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # e.g., --build-arg VERSION=0.0.1
       context: .
       dockerfile: Dockerfile
-    image: cisagov/pca-report-library
+    image: cisagov/pca-report-library:0.0.1
     init: true
     restart: "no"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     image: cisagov/pca-report-library
     init: true
     restart: "no"
-    environment:
-      - ECHO_MESSAGE=Hello World from docker-compose!
 
   pca-report-library-version:
     # Run the container to collect version information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,14 @@ secrets:
     file: ./src/secrets/quote.txt
 
 services:
-  example:
+  pca-report-library:
     # Run the container normally
     build:
       # VERSION must be specified on the command line:
       # e.g., --build-arg VERSION=0.0.1
       context: .
       dockerfile: Dockerfile
-    image: cisagov/example
+    image: cisagov/pca-report-library
     init: true
     restart: "no"
     environment:
@@ -24,9 +24,9 @@ services:
       - source: quote_txt
         target: quote.txt
 
-  example-version:
+  pca-report-library-version:
     # Run the container to collect version information
-    image: cisagov/example
+    image: cisagov/pca-report-library
     init: true
     restart: "no"
     command: --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # e.g., --build-arg VERSION=0.0.1
       context: .
       dockerfile: Dockerfile
-    image: cisagov/pca-report-library:0.0.1
+    image: cisagov/pca-report-library
     init: true
     restart: "no"
     environment:
@@ -23,7 +23,7 @@ services:
 
   pca-report-library-version:
     # Run the container to collect version information
-    image: cisagov/pca-report-library:0.0.1
+    image: cisagov/pca-report-library
     init: true
     restart: "no"
     command: pca-report-generator --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   pca-report-library-version:
     # Run the container to collect version information
-    image: cisagov/pca-report-library
+    image: cisagov/pca-report-library:0.0.1
     init: true
     restart: "no"
     command: pca-report-generator --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,4 +24,4 @@ services:
     image: cisagov/pca-report-library
     init: true
     restart: "no"
-    command: pca-report-generator --version
+    command: --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,6 @@ services:
     restart: "no"
     environment:
       - ECHO_MESSAGE=Hello World from docker-compose!
-    secrets:
-      - source: quote_txt
-        target: quote.txt
 
   pca-report-library-version:
     # Run the container to collect version information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,6 @@ services:
     restart: "no"
     environment:
       - ECHO_MESSAGE=Hello World from docker-compose!
-    ports:
-      - target: 8080
-        published: 8080
-        protocol: tcp
-        mode: host
     secrets:
       - source: quote_txt
         target: quote.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 # Third-Party Libraries
 import pytest
 
-MAIN_SERVICE_NAME = "example"
+MAIN_SERVICE_NAME = "pca-report-library"
 VERSION_SERVICE_NAME = f"{MAIN_SERVICE_NAME}-version"
 
 

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -91,5 +91,5 @@ def test_container_version_label_matches(version_container):
         exec(f.read(), pkg_vars)  # nosec
     project_version = pkg_vars["__version__"]
     assert (
-        version_container.labels["version"] == project_version
+        version_container.labels["org.opencontainers.image.version"] == project_version
     ), "Dockerfile version label does not match project version"

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -11,9 +11,6 @@ import pytest
 ENV_VAR = "ECHO_MESSAGE"
 ENV_VAR_VAL = "Hello World from docker-compose!"
 READY_MESSAGE = "This is a debug message"
-SECRET_QUOTE = (
-    "There are no secrets better kept than the secrets everybody guesses."  # nosec
-)
 PCA_GENERATOR_QUOTE = (
     '# PCA_GENERATOR_IMAGE, defaults to "cisagov/pca-report-generator" if not set'
 )

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -8,8 +8,6 @@ import time
 # Third-Party Libraries
 import pytest
 
-ENV_VAR_VAL = "Hello World from docker-compose!"
-READY_MESSAGE = "This is a debug message"
 PCA_GENERATOR_QUOTE = (
     '# PCA_GENERATOR_IMAGE, defaults to "cisagov/pca-report-generator" if not set'
 )

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env pytest -vs
-"""Tests for example container."""
+"""Tests for pca-report-library container."""
 
 # Standard Python Libraries
 import os
@@ -45,7 +45,7 @@ def test_wait_for_ready(main_container):
 
 def test_wait_for_exits(main_container, version_container):
     """Wait for containers to exit."""
-    assert main_container.wait() == 127, "Container service (main) did not exit cleanly"
+    assert main_container.wait() == 0, "Container service (main) did not exit cleanly"
     assert (
         version_container.wait() == 0
     ), "Container service (version) did not exit cleanly"

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -14,6 +14,9 @@ READY_MESSAGE = "This is a debug message"
 SECRET_QUOTE = (
     "There are no secrets better kept than the secrets everybody guesses."  # nosec
 )
+PCA_GENERATOR_QUOTE = (
+    '# PCA_GENERATOR_IMAGE, defaults to "cisagov/pca-report-generator" if not set'
+)
 RELEASE_TAG = os.getenv("RELEASE_TAG")
 VERSION_FILE = "src/version.txt"
 
@@ -28,21 +31,21 @@ def test_container_count(dockerc):
 
 def test_wait_for_ready(main_container):
     """Wait for container to be ready."""
-    TIMEOUT = 10
+    TIMEOUT = 110
     for i in range(TIMEOUT):
-        if READY_MESSAGE in main_container.logs().decode("utf-8"):
+        if PCA_GENERATOR_QUOTE in main_container.logs().decode("utf-8"):
             break
         time.sleep(1)
     else:
         raise Exception(
             f"Container does not seem ready.  "
-            f'Expected "{READY_MESSAGE}" in the log within {TIMEOUT} seconds.'
+            f'Expected "{PCA_GENERATOR_QUOTE}" in the log within {TIMEOUT} seconds.'
         )
 
 
 def test_wait_for_exits(main_container, version_container):
     """Wait for containers to exit."""
-    assert main_container.wait() == 0, "Container service (main) did not exit cleanly"
+    assert main_container.wait() == 127, "Container service (main) did not exit cleanly"
     assert (
         version_container.wait() == 0
     ), "Container service (version) did not exit cleanly"
@@ -52,7 +55,9 @@ def test_output(main_container):
     """Verify the container had the correct output."""
     main_container.wait()  # make sure container exited if running test isolated
     log_output = main_container.logs().decode("utf-8")
-    assert SECRET_QUOTE in log_output, "Secret not found in log output."
+    assert (
+        PCA_GENERATOR_QUOTE in log_output
+    ), "PCA_GENERATOR_IMAGE quote not found in log output."
 
 
 @pytest.mark.skipif(

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -94,5 +94,5 @@ def test_container_version_label_matches(version_container):
         exec(f.read(), pkg_vars)  # nosec
     project_version = pkg_vars["__version__"]
     assert (
-        version_container.labels["org.opencontainers.image.version"] == project_version
+        version_container.labels["version"] == project_version
     ), "Dockerfile version label does not match project version"

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -8,7 +8,6 @@ import time
 # Third-Party Libraries
 import pytest
 
-ENV_VAR = "ECHO_MESSAGE"
 ENV_VAR_VAL = "Hello World from docker-compose!"
 READY_MESSAGE = "This is a debug message"
 PCA_GENERATOR_QUOTE = (


### PR DESCRIPTION
## 🗣 Description ##

Add the docker portions of pca-report-library into this repository

## 💭 Motivation and context ##

This change is required to get it up to speed with cisagov coding standards and is part of the plan to fully modernize pca-report-library. This repository will house the docker portions of pca-report-library while also maintaining the base skeleton-docker.

Resolves https://github.com/cisagov/pca-report-generator-docker/issues/2

## 🧪 Testing ##

Using pytest to test changes and pre-commit

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
